### PR TITLE
fix errors and fix alignment to flowchart

### DIFF
--- a/controllers/iterate.go
+++ b/controllers/iterate.go
@@ -54,7 +54,10 @@ func (r *ExperimentReconciler) doIteration(ctx context.Context, instance *v2alph
 
 	// record start time of experiment if not already set
 	if err := r.setStartTimeIfNotSet(ctx, instance); err != nil {
-		return ctrl.Result{}, err // TODO don't want to reconcile if there is an error
+		if err != nil {
+			log.Error(err, "Unable to set status.StartTime")
+		}
+		return ctrl.Result{}, nil
 	}
 
 	if !r.sufficientTimePassedSincePreviousIteration(ctx, instance) {
@@ -76,7 +79,7 @@ func (r *ExperimentReconciler) doIteration(ctx context.Context, instance *v2alph
 	// 1. has 4 entries: aggregatedMetrics, winnerAssessment, versionAssessments, weights
 	// 2. versionAssessments have entry for each version, objective
 	// 3. weights has entry for each version
-	// If not valid: r.failExperiment(context, instance)
+	// If not valid: return r.failExperiment(context, instance)
 
 	// update analytics in instance.status
 	instance.Status.Analysis = analysis


### PR DESCRIPTION
This PR does the following:

- Remove err from Reconcile returns. Now that we understand them we can consider thoughtfully applying them.
- insert missing return statements
- fix handling after terminal handler is called. Originally, it returned before the stubbed call to trigger the next experiment and the update of Status. Now the flow has been regularized and better matches the flowchart.