### PR TITLE
Simplifytests

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -2,22 +2,17 @@ name: Build, test and push etc3 controller
 
 on:
   push:
-    # Publish `main` as Docker `latest` image.
     branches:
-      - main
-    # Publish `v1.2.3` tags as releases.
+      - main # Publish `main` as Docker `latest` image.
     tags:
-      - v*
-  # Run tests for any PRs.
-  pull_request:
+      - v* # Publish `v1.2.3` tags as releases.
+  pull_request: # Run tests for any PRs.
 
 jobs:
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
+  # Ensure tests pass on PRs.
   build-and-test:
-    # Ensure test job passes before pushing image. Already done as part of make target, so ignoring.
-    # needs: build-and-test
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -40,26 +35,15 @@ jobs:
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
         export PATH=$PATH:/usr/local/kubebuilder/bin
-    # - name: Set up minikube
-    #   uses: manusa/actions-setup-minikube@v2.1.0
-    #   with:
-    #     minikube version: 'v1.13.1'
-    #     kubernetes version: 'v1.19.2'
-    #     driver: docker
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Test
       run: make test
 
-
+  # Push etc3 image to dockerhub
   build-and-push:
-    # Create docker image
-    # needs: build-and-test ## seems unnecessary
-
     runs-on: ubuntu-latest
-
     if: github.event_name == 'push'
-
     steps:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -42,6 +42,8 @@ jobs:
 
   # Push etc3 image to dockerhub
   build-and-push:
+    # Ensure test job passes before pushing image.		
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -40,12 +40,12 @@ jobs:
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
         export PATH=$PATH:/usr/local/kubebuilder/bin
-    - name: Set up minikube
-      uses: manusa/actions-setup-minikube@v2.1.0
-      with:
-        minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
-        driver: docker
+    # - name: Set up minikube
+    #   uses: manusa/actions-setup-minikube@v2.1.0
+    #   with:
+    #     minikube version: 'v1.13.1'
+    #     kubernetes version: 'v1.19.2'
+    #     driver: docker
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Test
@@ -53,8 +53,8 @@ jobs:
 
 
   build-and-push:
-    # Ensure test job passes before pushing image.
-    needs: build-and-test
+    # Create docker image
+    # needs: build-and-test ## seems unnecessary
 
     runs-on: ubuntu-latest
 
@@ -65,7 +65,6 @@ jobs:
     - uses: docker/setup-buildx-action@v1
     - uses: docker/login-action@v1
       with:
-        # registry: ${{ env.REGISTRY }}
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_SECRET }}
     - name: Get version


### PR DESCRIPTION
1. Removed Minikube from unit tests
2. Tests are run on PRs. No tests are run for code merges or tagged releases -- ok for now since we anyway don't have e2e tests (with built images to run in this repo). Only unit tests. 