### PR TITLE
add conformance experiment type

### DIFF
--- a/api/v2alpha1/constants.go
+++ b/api/v2alpha1/constants.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v2alpha1
 
 // StrategyType identifies the type of experiment type
-// +kubebuilder:validation:Enum=Canary;A/B;A/B/N;Performance;Conformance;BlueGreen
+// +kubebuilder:validation:Enum=Canary;A/B;A/B/N;Conformance;BlueGreen
 type StrategyType string
 
 const (
@@ -29,9 +29,6 @@ const (
 
 	// StrategyTypeABN indicates an experiment is a A/B/n experiment
 	StrategyTypeABN StrategyType = "A/B/N"
-
-	// StrategyTypePerformance indicates an experiment is a performance experiment
-	StrategyTypePerformance StrategyType = "Performance"
 
 	// StrategyTypeConformance indicates an experiment is a conformance experiment
 	StrategyTypeConformance StrategyType = "Conformance"
@@ -46,7 +43,6 @@ var ValidStrategyTypes []StrategyType = []StrategyType{
 	StrategyTypeCanary,
 	StrategyTypeAB,
 	StrategyTypeABN,
-	StrategyTypePerformance,
 	StrategyTypeConformance,
 	StrategyTypeBlueGreen,
 }

--- a/api/v2alpha1/constants.go
+++ b/api/v2alpha1/constants.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v2alpha1
 
 // StrategyType identifies the type of experiment type
-// +kubebuilder:validation:Enum=Canary;A/B;A/B/N;Performance;BlueGreen
+// +kubebuilder:validation:Enum=Canary;A/B;A/B/N;Performance;Conformance;BlueGreen
 type StrategyType string
 
 const (
@@ -33,6 +33,9 @@ const (
 	// StrategyTypePerformance indicates an experiment is a performance experiment
 	StrategyTypePerformance StrategyType = "Performance"
 
+	// StrategyTypeConformance indicates an experiment is a conformance experiment
+	StrategyTypeConformance StrategyType = "Conformance"
+
 	// StrategyTypeBlueGreen indicates an experiment is a blue-green experiment
 	StrategyTypeBlueGreen StrategyType = "BlueGreen"
 )
@@ -44,6 +47,7 @@ var ValidStrategyTypes []StrategyType = []StrategyType{
 	StrategyTypeAB,
 	StrategyTypeABN,
 	StrategyTypePerformance,
+	StrategyTypeConformance,
 	StrategyTypeBlueGreen,
 }
 

--- a/api/v2alpha1/experiment_types.go
+++ b/api/v2alpha1/experiment_types.go
@@ -177,7 +177,7 @@ type Weights struct {
 	MaxCandidateWeightIncrement *int32 `json:"maxCandidateWeightIncrement,omitempty" yaml:"maxCandidateWeightIncrement,omitempty"`
 
 	// Algorithm is the traffic split algorithm
-	// Default will be None for performance experiments,
+	// Default will be None for conformance experiments,
 	// "fixed_split" for bluegreen experiments, and
 	// "progressive" otherwise
 	// +optional

--- a/config/crd/bases/iter8.tools_experiments.yaml
+++ b/config/crd/bases/iter8.tools_experiments.yaml
@@ -270,7 +270,6 @@ spec:
                     - Canary
                     - A/B
                     - A/B/N
-                    - Performance
                     - Conformance
                     - BlueGreen
                     type: string

--- a/config/crd/bases/iter8.tools_experiments.yaml
+++ b/config/crd/bases/iter8.tools_experiments.yaml
@@ -271,6 +271,7 @@ spec:
                     - A/B
                     - A/B/N
                     - Performance
+                    - Conformance
                     - BlueGreen
                     type: string
                   weights:
@@ -279,7 +280,7 @@ spec:
                     properties:
                       algorithm:
                         description: Algorithm is the traffic split algorithm Default
-                          will be None for performance experiments, "fixed_split"
+                          will be None for conformance experiments, "fixed_split"
                           for bluegreen experiments, and "progressive" otherwise
                         enum:
                         - FixedSplit

--- a/controllers/target_test.go
+++ b/controllers/target_test.go
@@ -52,14 +52,14 @@ var _ = Describe("Target Acquisition", func() {
 		wantsName := "wants-target"
 		has := v2alpha1.NewExperiment(hasName, testNamespace).
 			WithTarget("unavailable-target").
-			WithStrategy(v2alpha1.StrategyTypePerformance).
+			WithStrategy(v2alpha1.StrategyTypeConformance).
 			WithHandlers(map[string]string{"start": "none", "finish": "none"}).
 			WithDuration(3, 2).
 			WithBaselineVersion("baseline", nil).
 			Build()
 		wants := v2alpha1.NewExperiment(wantsName, testNamespace).
 			WithTarget("unavailable-target").
-			WithStrategy(v2alpha1.StrategyTypePerformance).
+			WithStrategy(v2alpha1.StrategyTypeConformance).
 			WithHandlers(map[string]string{"start": "none", "finish": "none"}).
 			WithDuration(1, 1).
 			WithBaselineVersion("baseline", nil).
@@ -97,14 +97,14 @@ var _ = Describe("Finalizer", func() {
 		wantsName := "wants-target-finalizer"
 		has := v2alpha1.NewExperiment(hasName, testNamespace).
 			WithTarget("unavailable-target").
-			WithStrategy(v2alpha1.StrategyTypePerformance).
+			WithStrategy(v2alpha1.StrategyTypeConformance).
 			WithHandlers(map[string]string{"start": "none", "finish": "none"}).
 			WithDuration(3, 2).
 			WithBaselineVersion("baseline", nil).
 			Build()
 		wants := v2alpha1.NewExperiment(wantsName, testNamespace).
 			WithTarget("unavailable-target").
-			WithStrategy(v2alpha1.StrategyTypePerformance).
+			WithStrategy(v2alpha1.StrategyTypeConformance).
 			WithHandlers(map[string]string{"start": "none", "finish": "none"}).
 			WithDuration(1, 1).
 			WithBaselineVersion("baseline", nil).

--- a/controllers/validatation.go
+++ b/controllers/validatation.go
@@ -52,7 +52,7 @@ func (r *ExperimentReconciler) IsVersionInfoValid(ctx context.Context, instance 
 
 func candidatesMatchStrategy(s v2alpha1.ExperimentSpec) bool {
 	switch s.Strategy.Type {
-	case v2alpha1.StrategyTypeConformance, v2alpha1.StrategyTypePerformance:
+	case v2alpha1.StrategyTypeConformance:
 		return len(s.VersionInfo.Candidates) == 0
 	case v2alpha1.StrategyTypeAB, v2alpha1.StrategyTypeCanary, v2alpha1.StrategyTypeBlueGreen:
 		return len(s.VersionInfo.Candidates) == 1

--- a/controllers/validatation.go
+++ b/controllers/validatation.go
@@ -52,7 +52,7 @@ func (r *ExperimentReconciler) IsVersionInfoValid(ctx context.Context, instance 
 
 func candidatesMatchStrategy(s v2alpha1.ExperimentSpec) bool {
 	switch s.Strategy.Type {
-	case v2alpha1.StrategyTypePerformance:
+	case v2alpha1.StrategyTypeConformance, v2alpha1.StrategyTypePerformance:
 		return len(s.VersionInfo.Candidates) == 0
 	case v2alpha1.StrategyTypeAB, v2alpha1.StrategyTypeCanary, v2alpha1.StrategyTypeBlueGreen:
 		return len(s.VersionInfo.Candidates) == 1

--- a/controllers/validation_test.go
+++ b/controllers/validation_test.go
@@ -1,0 +1,128 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	v2alpha1 "github.com/iter8-tools/etc3/api/v2alpha1"
+	"github.com/iter8-tools/etc3/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validation of VersionInfo", func() {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, util.LoggerKey, ctrl.Log)
+	testNamespace := "default"
+
+	// The first test validates when no VersionInfo is present (all strategies)
+	// The way to have no versions is to have no VersionInfo
+
+	Context("Experiment is a Conformance test", func() {
+		bldr := v2alpha1.NewExperiment("conformance-test", testNamespace).
+			WithTarget("target").
+			WithStrategy(v2alpha1.StrategyTypeConformance)
+		It("should be valid only when 1 version is identified", func() {
+			By("returning false when no versions are specified")
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning true when 1 version is identified")
+			bldr = bldr.WithBaselineVersion("baseline", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeTrue())
+			By("returning false when more than 1 version is identified")
+			bldr = bldr.WithCandidateVersion("candidate-1", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+		})
+	})
+
+	Context("Experiment is an AB test", func() {
+		bldr := v2alpha1.NewExperiment("ab-test", testNamespace).
+			WithTarget("target").
+			WithStrategy(v2alpha1.StrategyTypeAB)
+		It("should be valid only when 2 versions are identified", func() {
+			By("returning false when no versions are specified")
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning false when 1 version is identified")
+			bldr = bldr.WithBaselineVersion("baseline", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning true when exactly than 2 versions are identified")
+			bldr = bldr.WithCandidateVersion("candidate-1", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeTrue())
+			By("returning false when more than 2 version are identified")
+			bldr = bldr.WithCandidateVersion("candidate-2", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+		})
+	})
+
+	Context("Experiment is an Canary test", func() {
+		bldr := v2alpha1.NewExperiment("canary-test", testNamespace).
+			WithTarget("target").
+			WithStrategy(v2alpha1.StrategyTypeCanary)
+		It("should be valid only when 2 versions are identified", func() {
+			By("returning false when no versions are specified")
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning false when 1 version is identified")
+			bldr = bldr.WithBaselineVersion("baseline", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning true when exactly than 2 versions are identified")
+			bldr = bldr.WithCandidateVersion("candidate-1", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeTrue())
+			By("returning false when more than 2 version are identified")
+			bldr = bldr.WithCandidateVersion("candidate-2", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+		})
+	})
+
+	Context("Experiment is an BlueGreen test", func() {
+		bldr := v2alpha1.NewExperiment("bluegreen-test", testNamespace).
+			WithTarget("target").
+			WithStrategy(v2alpha1.StrategyTypeBlueGreen)
+		It("should be valid only when 2 versions are identified", func() {
+			By("returning false when no versions are specified")
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning false when 1 version is identified")
+			bldr = bldr.WithBaselineVersion("baseline", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning true when exactly than 2 versions are identified")
+			bldr = bldr.WithCandidateVersion("candidate-1", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeTrue())
+			By("returning false when more than 2 version are identified")
+			bldr = bldr.WithCandidateVersion("candidate-2", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+		})
+	})
+
+	Context("Experiment is an ABN test", func() {
+		bldr := v2alpha1.NewExperiment("abn-test", testNamespace).
+			WithTarget("target").
+			WithStrategy(v2alpha1.StrategyTypeABN)
+		It("should be valid only when more than 2 or more versions are identified", func() {
+			By("returning false when no versions are specified")
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning false when 1 version is identified")
+			bldr = bldr.WithBaselineVersion("baseline", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeFalse())
+			By("returning false when 2 versions are identified")
+			bldr = bldr.WithCandidateVersion("candidate-1", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeTrue())
+			By("returning true when more than 2 version are identified")
+			bldr = bldr.WithCandidateVersion("candidate-2", nil)
+			Expect(reconciler.IsVersionInfoValid(ctx, bldr.Build())).Should(BeTrue())
+		})
+	})
+
+})

--- a/controllers/weights.go
+++ b/controllers/weights.go
@@ -39,8 +39,7 @@ import (
 
 func shouldRedistribute(instance *v2alpha1.Experiment) bool {
 	experimentType := instance.Spec.Strategy.Type
-	if experimentType == v2alpha1.StrategyTypePerformance ||
-		experimentType == v2alpha1.StrategyTypeConformance {
+	if experimentType == v2alpha1.StrategyTypeConformance {
 		return false
 	}
 	algorithm := instance.Spec.GetAlgorithm()

--- a/controllers/weights.go
+++ b/controllers/weights.go
@@ -39,7 +39,8 @@ import (
 
 func shouldRedistribute(instance *v2alpha1.Experiment) bool {
 	experimentType := instance.Spec.Strategy.Type
-	if experimentType == v2alpha1.StrategyTypePerformance {
+	if experimentType == v2alpha1.StrategyTypePerformance ||
+		experimentType == v2alpha1.StrategyTypeConformance {
 		return false
 	}
 	algorithm := instance.Spec.GetAlgorithm()

--- a/controllers/weights_test.go
+++ b/controllers/weights_test.go
@@ -34,10 +34,10 @@ var _ = Describe("Weight Patching", func() {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, util.LoggerKey, ctrl.Log)
 
-	Context("When experimentType is Performance", func() {
+	Context("When experimentType is Conformance", func() {
 		experiment := v2alpha1.NewExperiment("noVersionInfo", namespace).
 			WithTarget("target").
-			WithStrategy(v2alpha1.StrategyTypePerformance).
+			WithStrategy(v2alpha1.StrategyTypeConformance).
 			Build()
 		It("should succeed without error", func() {
 			Expect(redistributeWeight(ctx, experiment, restCfg)).Should(Succeed())


### PR DESCRIPTION
This PR adds the conformance experiment type. It does not remove the performance experiment type. This remains to allow test cases in other projects such as https://github.com/iter8-tools/knative-tasks to be adjusted. This is the first of two steps to implement issue https://github.com/iter8-tools/etc3/issues/87.