### PR TITLE
fixed documentation for Body field in metrics

### DIFF
--- a/api/v2alpha2/metric_types.go
+++ b/api/v2alpha2/metric_types.go
@@ -105,7 +105,6 @@ type MetricSpec struct {
 
 	// Body is the string used to construct the (json) body of the HTTP request
 	// Body may be templated, in which Iter8 will attempt to substitute placeholders in the template at query time using version information.
-	// This field is relevant only when Method == POST
 	// +optional
 	Body *string `json:"body,omitempty" yaml:"body,omitempty"`
 


### PR DESCRIPTION
I was under the (wrong) impression that HTTP servers ignore body when the request method was `GET`. This  is not true as I found out while reading the NewRelic documentation carefully. This does not change anything in metrics CRD, except the incorrect documentation I had written earlier.