### PR TITLE
rename action jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@
 
 This section is for iter8 developers and contains documentation on running and testing the etc3 controller locally.
 
-### Install KFServing and iter8-kfserving Domain Package
-Pre-requisites: `kubectl` with acccess to a kubernetes cluster.
+### Install Iter8
 
-To install KFServing and the iter8-kfserving domain package, follow Steps 1 and 2 from [here](https://github.com/iter8-tools/iter8-kfserving#quick-start-on-minikube).
+To install Iter8 see [here](https://iter8.tools).
 
-### Partial Install of iter8-kfserving Domain
-For dev/local-test purposes, it is convenient to run the etc3 locally. Follow the above instructions for iter8-kfserving installation, and then delete the etc3 controller as follows.
+### Delete etc3 from Cluster
+After installing Iter8, delete the etc3 controller:
 
 ```
 kubectl delete deployment iter8-controller-manager -n iter8-system
@@ -37,12 +36,12 @@ You should now be able to access the iter8-analytics service using the OpenAPI U
 make manager
 export ITER8_NAMESPACE=iter8-system
 export ITER8_ANALYTICS_ENDPOINT=http://127.0.0.1:8080/v2/analytics_results
-export DEFAULTS_DIR=../iter8-kfserving/install/iter8-controller/configmaps/defaults
-export HANDLERS_DIR=../iter8-kfserving/install/iter8-controller/configmaps/handlers
+export HANDLERS_DIR=../iter8-install/core/iter8-handler
 bin/manager
 ``` 
 
-### Test etc3
+### Testing etc3
+
 ```
 make test
 ```

--- a/config/crd/bases/iter8.tools_experiments.yaml
+++ b/config/crd/bases/iter8.tools_experiments.yaml
@@ -678,7 +678,6 @@ spec:
                                 (json) body of the HTTP request Body may be templated,
                                 in which Iter8 will attempt to substitute placeholders
                                 in the template at query time using version information.
-                                This field is relevant only when Method == POST
                               type: string
                             description:
                               description: Text description of the metric

--- a/config/crd/bases/iter8.tools_metrics.yaml
+++ b/config/crd/bases/iter8.tools_metrics.yaml
@@ -55,7 +55,7 @@ spec:
                 description: Body is the string used to construct the (json) body
                   of the HTTP request Body may be templated, in which Iter8 will attempt
                   to substitute placeholders in the template at query time using version
-                  information. This field is relevant only when Method == POST
+                  information.
                 type: string
               description:
                 description: Text description of the metric

--- a/controllers/experiment_controller.go
+++ b/controllers/experiment_controller.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"time"
@@ -466,7 +467,7 @@ func (r *ExperimentReconciler) checkHandlerStatus(ctx context.Context, instance 
 		}
 	case HandlerStatusFailed:
 		// a failure handler failed; don't call it again; just stop
-		result, err := r.endExperiment(ctx, instance, "Failure handler failed")
+		result, err := r.endExperiment(ctx, instance, fmt.Sprintf("%s actions failed", handlerType))
 		return stop, result, err
 	default: // HandlerStatusNotLaunched, HandlerStatusNoHandler:
 		return !stop, dummyResult, nil

--- a/controllers/handler.go
+++ b/controllers/handler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/iter8-tools/etc3/api/v2alpha2"
@@ -288,8 +287,7 @@ func HandlerJobFailed(handlerJob *batchv1.Job) bool {
 
 // generate job name
 func jobName(instance *v2alpha2.Experiment, handler string, handlerInstance *int) string {
-	uid := string(instance.UID)
-	name := fmt.Sprintf("%s-handler-%s-%s", handler, instance.Name, uid[strings.LastIndex(uid, "-")+1:])
+	name := fmt.Sprintf("%s-%s", instance.Name, handler)
 	if handlerInstance != nil {
 		name = fmt.Sprintf("%s-%d", name, *handlerInstance)
 	}

--- a/controllers/handler_test.go
+++ b/controllers/handler_test.go
@@ -15,6 +15,8 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
+
 	v2alpha2 "github.com/iter8-tools/etc3/api/v2alpha2"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,6 +57,7 @@ var _ = Describe("Handlers Run", func() {
 			Eventually(func() bool {
 				handlerJob := &batchv1.Job{}
 				jbNm := jobName(experiment, handler, nil)
+				Expect(jbNm).To(Equal(fmt.Sprintf("%s-%s", experiment.GetName(), handler)))
 				err := k8sClient.Get(ctx(), types.NamespacedName{Name: jbNm, Namespace: "iter8"}, handlerJob)
 				if err != nil {
 					return false
@@ -88,6 +91,7 @@ var _ = Describe("Handlers Run", func() {
 			Eventually(func() bool {
 				handlerJob := &batchv1.Job{}
 				jbNm := jobName(experiment, handler, nil)
+				Expect(jbNm).To(Equal(fmt.Sprintf("%s-%s", experiment.GetName(), handler)))
 				err := k8sClient.Get(ctx(), types.NamespacedName{Name: jbNm, Namespace: "iter8"}, handlerJob)
 				if err != nil {
 					return false
@@ -127,6 +131,7 @@ var _ = Describe("Handlers Run", func() {
 			Eventually(func() bool {
 				handlerJob := &batchv1.Job{}
 				jbNm := jobName(experiment, handler, &testLoop)
+				Expect(jbNm).To(Equal(fmt.Sprintf("%s-%s-%d", experiment.GetName(), handler, testLoop)))
 				err := k8sClient.Get(ctx(), types.NamespacedName{Name: jbNm, Namespace: "iter8"}, handlerJob)
 				if err != nil {
 					return false


### PR DESCRIPTION
Resolves #199 and #191 

Renames action job to make debugging handlers easier by standardizing names.
Includes updates to 2 generated yaml files that should have been included included in a previous build