### PR TITLE
report failure when handler fails

### DIFF
--- a/controllers/experiment_controller.go
+++ b/controllers/experiment_controller.go
@@ -468,7 +468,9 @@ func (r *ExperimentReconciler) checkHandlerStatus(ctx context.Context, instance 
 		}
 	case HandlerStatusFailed:
 		// a failure handler failed; don't call it again; just stop
-		result, err := r.endExperiment(ctx, instance, fmt.Sprintf("%s actions failed", handlerType))
+		msg := fmt.Sprintf("%s actions failed", handlerType)
+		r.recordExperimentFailed(ctx, instance, v2alpha2.ReasonHandlerFailed, msg)
+		result, err := r.endExperiment(ctx, instance, msg)
 		return stop, result, err
 	default: // HandlerStatusNotLaunched, HandlerStatusNoHandler:
 		return !stop, dummyResult, nil


### PR DESCRIPTION
While testing slack notifications it was observed that the failure of a handler while reported did not result in the status condition `Failed` being set to true.  This fixes this. 

This was tested manually but it is not immediately clear how to write a unit test -- in the env test environment the jobs do not run and are not failed.