### PR TITLE
also run loop handler after last loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,7 @@ CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
+
+coverage:
+	@echo "test coverage: $(shell go tool cover -func cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}')"
+


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>

Fixes https://github.com/iter8-tools/iter8/issues/734
Add make target to compute test coverage