### PR TITLE
Remove Status.InitTime and ExperimentStageWaiting

### DIFF
--- a/api/v2beta1/constants.go
+++ b/api/v2beta1/constants.go
@@ -96,14 +96,10 @@ const (
 )
 
 // ExperimentStageType identifies valid stages of an experiment
-// +kubebuilder:validation:Enum:=Waiting;Initializing;Running;Finishing;Completed
+// +kubebuilder:validation:Enum:=Initializing;Running;Finishing;Completed
 type ExperimentStageType string
 
 const (
-	// ExperimentStageWaiting indicates the experiment is not yet scheduled to run because it
-	// does not yet have exclusive experiment access to the target
-	ExperimentStageWaiting ExperimentStageType = "Waiting"
-
 	// ExperimentStageInitializing indicates an experiment has acquired access to the target
 	// and a start handler, if  any, is running
 	ExperimentStageInitializing ExperimentStageType = "Initializing"
@@ -122,7 +118,6 @@ const (
 // After Determines if a stage is after another
 func (stage ExperimentStageType) After(otherStage ExperimentStageType) bool {
 	orderedStages := []ExperimentStageType{
-		ExperimentStageWaiting,
 		ExperimentStageInitializing,
 		ExperimentStageRunning,
 		ExperimentStageFinishing,

--- a/api/v2beta1/defaults_test.go
+++ b/api/v2beta1/defaults_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Initialization", func() {
 			WithVersion("baseline").WithVersion("candidate").
 			Build()
 		Specify("status values should be unset", func() {
-			Expect(experiment.Status.InitTime).Should(BeNil())
+			Expect(experiment.Status.StartTime).Should(BeNil())
 			Expect(experiment.Status.LastUpdateTime).Should(BeNil())
 			Expect(experiment.Status.CompletedIterations).Should(BeNil())
 			Expect(len(experiment.Status.Conditions)).Should(Equal(0))
@@ -73,7 +73,7 @@ var _ = Describe("Initialization", func() {
 			By("Initializing Status")
 			experiment.InitializeStatus()
 			By("Inspecting Status")
-			Expect(experiment.Status.InitTime).ShouldNot(BeNil())
+			Expect(experiment.Status.StartTime).ShouldNot(BeNil())
 			Expect(experiment.Status.LastUpdateTime).ShouldNot(BeNil())
 			Expect(experiment.Status.CompletedIterations).ShouldNot(BeNil())
 			Expect(len(experiment.Status.Conditions)).Should(Equal(2))

--- a/api/v2beta1/experiment_types.go
+++ b/api/v2beta1/experiment_types.go
@@ -266,12 +266,8 @@ type ExperimentStatus struct {
 	// +optional
 	Conditions []*ExperimentCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 
-	// InitTime is the times when the experiment is initialized (experiment CR is new)
-	// +optional
-	// matches example
-	InitTime *metav1.Time `json:"initTime,omitempty" yaml:"initTime,omitempty"`
-
-	// StartTime is the time when the experiment starts (after the start handler finished)
+	// StartTime is the time when the experiment is created. It is set by the controller
+	// when the experiment is initialized.
 	// +optional
 	// matches
 	StartTime *metav1.Time `json:"startTime,omitempty" yaml:"startTime,omitempty"`

--- a/api/v2beta1/status.go
+++ b/api/v2beta1/status.go
@@ -76,7 +76,7 @@ func (e *Experiment) InitializeStatus() {
 
 	e.Status.LastUpdateTime = &now // metav1.Now()
 
-	stage := ExperimentStageWaiting
+	stage := ExperimentStageInitializing
 	e.Status.Stage = &stage
 
 	e.TestingPattern()

--- a/api/v2beta1/status.go
+++ b/api/v2beta1/status.go
@@ -72,7 +72,7 @@ func (e *Experiment) InitializeStatus() {
 	e.Status.addCondition(ExperimentConditionExperimentFailed, corev1.ConditionFalse)
 
 	now := metav1.Now()
-	e.Status.InitTime = &now // metav1.Now()
+	e.Status.StartTime = &now // metav1.Now()
 
 	e.Status.LastUpdateTime = &now // metav1.Now()
 

--- a/api/v2beta1/zz_generated.deepcopy.go
+++ b/api/v2beta1/zz_generated.deepcopy.go
@@ -490,10 +490,6 @@ func (in *ExperimentStatus) DeepCopyInto(out *ExperimentStatus) {
 			}
 		}
 	}
-	if in.InitTime != nil {
-		in, out := &in.InitTime, &out.InitTime
-		*out = (*in).DeepCopy()
-	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
 		*out = (*in).DeepCopy()

--- a/config/crd/bases/iter8.tools_experiments.yaml
+++ b/config/crd/bases/iter8.tools_experiments.yaml
@@ -646,11 +646,6 @@ spec:
                   - value
                   type: object
                 type: array
-              initTime:
-                description: InitTime is the times when the experiment is initialized
-                  (experiment CR is new) matches example
-                format: date-time
-                type: string
               lastUpdateTime:
                 description: LastUpdateTime is the last time iteration has been updated
                 format: date-time
@@ -846,15 +841,15 @@ spec:
                 description: Stage indicates where the experiment is in its process
                   of execution
                 enum:
-                - Waiting
                 - Initializing
                 - Running
                 - Finishing
                 - Completed
                 type: string
               startTime:
-                description: StartTime is the time when the experiment starts (after
-                  the start handler finished) matches
+                description: StartTime is the time when the experiment is created.
+                  It is set by the controller when the experiment is initialized.
+                  matches
                 format: date-time
                 type: string
               testingPattern:

--- a/controllers/experiment_controller.go
+++ b/controllers/experiment_controller.go
@@ -78,7 +78,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// if object not found, it has been deleted
 		if errors.IsNotFound(err) {
 			log.Info("Experiment not found")
-			// we make sure to have deleted all jobs and trigger any waiting experiment
+			// we make sure to have deleted all jobs
 			r.cleanupDeletedExperiments(ctx, instance)
 			return ctrl.Result{}, nil
 		}
@@ -127,13 +127,6 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// TODO move to validating web hook
 	if !r.IsExperimentValid(ctx, instance) {
 		return r.failExperiment(ctx, instance, nil)
-	}
-
-	// advance stage from Waiting to Initializing
-	// when we advance for the first time, we exit to force update; will be retriggered
-	if ok := r.advanceStage(ctx, instance, v2beta1.ExperimentStageInitializing); ok {
-		log.Info("Update stage advance to: Initializing")
-		return r.endRequest(ctx, instance)
 	}
 
 	// RUN START HANDLER if necessary

--- a/controllers/experiment_controller.go
+++ b/controllers/experiment_controller.go
@@ -91,7 +91,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	ctx = context.WithValue(ctx, OriginalStatusKey, instance.Status.DeepCopy())
 
 	// If instance has never been seen before, initialize status object
-	if instance.Status.InitTime == nil {
+	if instance.Status.StartTime == nil {
 		instance.InitializeStatus()
 		if err := r.Status().Update(ctx, instance); err != nil {
 			log.Error(err, "Failed to update Status after initialization.")

--- a/controllers/experiment_controller_test.go
+++ b/controllers/experiment_controller_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Experiment Validation", func() {
 			By("Getting experiment after late initialization has run (spec.Duration !=- nil)")
 			Eventually(func() bool {
 				return hasValue(testName, testNamespace, func(exp *v2beta1.Experiment) bool {
-					return exp.Status.InitTime != nil &&
+					return exp.Status.StartTime != nil &&
 						exp.Status.LastUpdateTime != nil &&
 						exp.Status.CompletedIterations != nil &&
 						len(exp.Status.Conditions) == 2

--- a/controllers/iterate.go
+++ b/controllers/iterate.go
@@ -69,11 +69,6 @@ func (r *ExperimentReconciler) doIteration(ctx context.Context, instance *v2beta
 	log.Info("doIteration called")
 	defer log.Info("doIteration completed")
 
-	// record start time of experiment if not already set
-	if err := r.setStartTimeIfNotSet(ctx, instance); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// If we've already executed as many iterations as requested, we  should finish the experiment
 	// Check here since may have executed a loop handler
 	if !moreIterationsNeeded(instance) {
@@ -148,19 +143,6 @@ func (r *ExperimentReconciler) doIteration(ctx context.Context, instance *v2beta
 
 	// Not of loop or there is no loop handler --> schedule next iteration
 	return r.endRequest(ctx, instance, instance.Spec.GetIntervalAsDuration())
-}
-
-func (r *ExperimentReconciler) setStartTimeIfNotSet(ctx context.Context, instance *v2beta1.Experiment) error {
-	if instance.Status.StartTime == nil {
-		now := metav1.Now()
-		instance.Status.StartTime = &now
-
-		if err := r.Status().Update(ctx, instance); err != nil {
-			Logger(ctx).Info("Failed to update when initializing status: " + err.Error())
-			return err
-		}
-	}
-	return nil
 }
 
 func (r *ExperimentReconciler) completeIteration(ctx context.Context, instance *v2beta1.Experiment) {


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>
Addresses part of issue https://github.com/iter8-tools/iter8/issues/961: removal of `Status.InitTime` and of `ExperimentStageWaiting`