### PR TITLE
apply to all branches

### DIFF
--- a/.github/workflows/build-and-push-etc3.yaml
+++ b/.github/workflows/build-and-push-etc3.yaml
@@ -5,7 +5,8 @@ on:
   release:
     types: [published]
   push:
-    # run test and push on all branches
+    branches:
+    - '**' # run test and push on all branches
     tags:
       - v* # Publish `v1.2.3` tags as releases.
   pull_request: # Run tests for any PRs.

--- a/.github/workflows/build-and-push-etc3.yaml
+++ b/.github/workflows/build-and-push-etc3.yaml
@@ -8,7 +8,7 @@ on:
     branches:
     - '**' # run test and push on all branches
     tags:
-      - v* # Publish `v1.2.3` tags as releases.
+    - v* # Publish `v1.2.3` tags as releases.
   pull_request: # Run tests for any PRs.
 
 jobs:


### PR DESCRIPTION
Fix workflow to apply to all branches. It seems that if any filters are specified (we have for tags) then we should for all.  Added explicit filter for branches.

Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>