### PR TITLE
fixes to coverage and docker push workflows

### DIFF
--- a/.github/workflows/build-and-push-etc3.yaml
+++ b/.github/workflows/build-and-push-etc3.yaml
@@ -41,7 +41,7 @@ jobs:
       run: make test # includes vet and lint (staticcheck)
     - name: Enforce coverage
       run: |
-        export COVERAGE=$(go tool cover -func cover.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+        export COVERAGE=$(go tool cover -func coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
         echo "code coverage is at ${COVERAGE}"
         if [ 1 -eq "$(echo "${COVERAGE} > 79.0" | bc)" ]; then \
           echo "all good... coverage is at or above 79.0%"; 
@@ -103,7 +103,9 @@ jobs:
     - name: Test With Coverage
       run: make test # make target already does coverage
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage.out
 
   # Push etc3 images (controller and taskrunner) to dockerhub
   # run only on push and release events; not pull-requests

--- a/.github/workflows/build-and-push-etc3.yaml
+++ b/.github/workflows/build-and-push-etc3.yaml
@@ -101,7 +101,7 @@ jobs:
         chmod +x kubebuilder && mv kubebuilder /usr/local/bin/
         export PATH=$PATH:/usr/local/kubebuilder/bin
     - name: Test With Coverage
-      run: go test -gcflags=-l -v  -coverprofile=coverage.txt -covermode=atomic ./...
+      run: make test # make target already does coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
 
@@ -127,6 +127,8 @@ jobs:
           echo "VERSION=$(echo $tarref | sed -e 's/^v//')" >> $GITHUB_ENV
         elif [[ "${{ github.ref }}" == *"main" ]]; then
           echo "VERSION=latest" >> $GITHUB_ENV
+        else
+          echo "VERSION=$tarref" >> $GITHUB_ENV
         fi
     - name: Get owner and repo
       run: |

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet staticcheck ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=$(START_TIMEOUT) go test  ./... -coverprofile=coverage.txt -covermode=atomic 
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=$(START_TIMEOUT) go test  ./... -coverprofile=coverage.out -covermode=atomic 
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test-iter8ctl:
@@ -140,4 +140,4 @@ rm -rf $$TMP_DIR ;\
 endef
 
 coverage:
-	@echo "test coverage: $(shell go tool cover -func cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}')"
+	@echo "test coverage: $(shell go tool cover -func coverage.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}')"

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet staticcheck ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=$(START_TIMEOUT) go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=$(START_TIMEOUT) go test  ./... -coverprofile=coverage.txt -covermode=atomic 
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test-iter8ctl:


### PR DESCRIPTION
Fix coverage workflow: use `make test` so control plane has time to start
Fix build-and-push workflow to use branch name as version name when not tag/main

Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>